### PR TITLE
patch for some invalid test code

### DIFF
--- a/primitives/core/src/offchain/testing.rs
+++ b/primitives/core/src/offchain/testing.rs
@@ -368,7 +368,7 @@ impl offchain::Externalities for TestOffchainExt {
 				Ok(0)
 			} else {
 				let read = std::cmp::min(buffer.len(), response[req.read..].len());
-				buffer[0..read].copy_from_slice(&response[req.read..read]);
+				buffer[0..read].copy_from_slice(&response[req.read..(read + req.read)]);
 				req.read += read;
 				Ok(read)
 			}


### PR DESCRIPTION
The code reads some data into a buffer but it assumes that in rust ranges go from `start` to `how many bytes` but in reality they go from `start` to `end`. In all likelihood this code path has never executed under any reasonable scenario